### PR TITLE
#29 fix(identity): execute registration with retry strategy

### DIFF
--- a/SmartEventBooking.Infrastructure.UnitTests/Identity/AuthServiceTests.cs
+++ b/SmartEventBooking.Infrastructure.UnitTests/Identity/AuthServiceTests.cs
@@ -29,6 +29,10 @@ public class AuthServiceTests
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _loggerMock = new Mock<ILogger<AuthService>>();
 
+        _unitOfWorkMock
+            .Setup(x => x.ExecuteWithStrategyAsync(It.IsAny<Func<Task<AuthResultDto>>>(), default))
+            .Returns((Func<Task<AuthResultDto>> operation, CancellationToken _) => operation());
+
         _authService = new AuthService(
             _userManagerMock.Object,
             _signInManagerMock.Object,
@@ -84,6 +88,7 @@ public class AuthServiceTests
         addedDomainUser.Id.Should().Be(createdUser.Id);
 
         _userRepositoryMock.Verify(x => x.Add(It.IsAny<User>()), Times.Once);
+        _unitOfWorkMock.Verify(x => x.ExecuteWithStrategyAsync(It.IsAny<Func<Task<AuthResultDto>>>(), default), Times.Once);
         _unitOfWorkMock.Verify(x => x.BeginTransactionAsync(default), Times.Once);
         _unitOfWorkMock.Verify(x => x.CommitTransactionAsync(default), Times.Once);
         _signInManagerMock.Verify(x => x.SignInAsync(createdUser, false, null), Times.Once);
@@ -117,6 +122,7 @@ public class AuthServiceTests
         result.Succeeded.Should().BeFalse();
         result.Errors.Should().ContainSingle().Which.Should().Be("Role assignment failed");
 
+        _unitOfWorkMock.Verify(x => x.ExecuteWithStrategyAsync(It.IsAny<Func<Task<AuthResultDto>>>(), default), Times.Once);
         _unitOfWorkMock.Verify(x => x.BeginTransactionAsync(default), Times.Once);
         _unitOfWorkMock.Verify(x => x.RollbackTransactionAsync(default), Times.Once);
         _userRepositoryMock.Verify(x => x.Add(It.IsAny<User>()), Times.Never);
@@ -149,6 +155,7 @@ public class AuthServiceTests
         result.Succeeded.Should().BeFalse();
         result.Errors.Should().ContainSingle().Which.Should().Be("Password is too weak");
 
+        _unitOfWorkMock.Verify(x => x.ExecuteWithStrategyAsync(It.IsAny<Func<Task<AuthResultDto>>>(), default), Times.Once);
         _unitOfWorkMock.Verify(x => x.BeginTransactionAsync(default), Times.Once);
         _unitOfWorkMock.Verify(x => x.RollbackTransactionAsync(default), Times.Once);
         _userManagerMock.Verify(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);

--- a/src/SmartEventBooking.Application/Abstractions/Repositories/IUnitOfWork.cs
+++ b/src/SmartEventBooking.Application/Abstractions/Repositories/IUnitOfWork.cs
@@ -4,6 +4,7 @@ namespace SmartEventBooking.Application.Abstractions.Repositories
     public interface IUnitOfWork : IAsyncDisposable, IDisposable
     {
         Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+        Task<TResult> ExecuteWithStrategyAsync<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken = default);
         Task BeginTransactionAsync(CancellationToken cancellationToken = default);
         Task CommitTransactionAsync(CancellationToken cancellationToken = default);
         Task RollbackTransactionAsync(CancellationToken cancellationToken = default);

--- a/src/SmartEventBooking.Infrastructure/Identity/AuthService.cs
+++ b/src/SmartEventBooking.Infrastructure/Identity/AuthService.cs
@@ -34,69 +34,80 @@ namespace SmartEventBooking.Infrastructure.Identity
         {
             _logger.LogInformation("Starting registration for user {Email}", dto.Email);
 
-            await _unitOfWork.BeginTransactionAsync();
+            ApplicationUser? createdUser = null;
 
-            try
+            var result = await _unitOfWork.ExecuteWithStrategyAsync(async () =>
             {
-                var appUser = new ApplicationUser
-                {
-                    Id = Guid.NewGuid(),
-                    UserName = dto.Email,
-                    Email = dto.Email
-                };
+                await _unitOfWork.BeginTransactionAsync();
 
-                var result = await _userManager.CreateAsync(appUser, dto.Password);
-
-                if (!result.Succeeded)
+                try
                 {
-                    var errors = string.Join(", ", result.Errors.Select(e => e.Description));
-                    _logger.LogWarning("Identity user creation failed for {Email}: {Errors}", dto.Email, errors);
-                    
-                    await _unitOfWork.RollbackTransactionAsync();
-                    return new AuthResultDto
+                    var appUser = new ApplicationUser
                     {
-                        Succeeded = false,
-                        Errors = result.Errors.Select(e => e.Description)
+                        Id = Guid.NewGuid(),
+                        UserName = dto.Email,
+                        Email = dto.Email
                     };
+
+                    createdUser = appUser;
+
+                    var result = await _userManager.CreateAsync(appUser, dto.Password);
+
+                    if (!result.Succeeded)
+                    {
+                        var errors = string.Join(", ", result.Errors.Select(e => e.Description));
+                        _logger.LogWarning("Identity user creation failed for {Email}: {Errors}", dto.Email, errors);
+
+                        await _unitOfWork.RollbackTransactionAsync();
+                        return new AuthResultDto
+                        {
+                            Succeeded = false,
+                            Errors = result.Errors.Select(e => e.Description)
+                        };
+                    }
+
+                    var addToRoleResult = await _userManager.AddToRoleAsync(appUser, RoleConstants.User);
+                    if (!addToRoleResult.Succeeded)
+                    {
+                        var errors = string.Join(", ", addToRoleResult.Errors.Select(e => e.Description));
+                        _logger.LogWarning("Adding user {Email} to role failed: {Errors}", dto.Email, errors);
+
+                        await _unitOfWork.RollbackTransactionAsync();
+                        return new AuthResultDto
+                        {
+                            Succeeded = false,
+                            Errors = addToRoleResult.Errors.Select(e => e.Description)
+                        };
+                    }
+
+                    var domainUser = new User
+                    {
+                        Id = appUser.Id,
+                        FirstName = dto.FirstName,
+                        LastName = dto.LastName
+                    };
+                    _userRepository.Add(domainUser);
+
+                    await _unitOfWork.CommitTransactionAsync();
+
+                    _logger.LogInformation("User {Email} registered successfully", dto.Email);
+                }
+                catch (Exception ex)
+                {
+                    await _unitOfWork.RollbackTransactionAsync();
+                    _logger.LogError(ex, "An error occurred during registration for user {Email}", dto.Email);
+                    throw;
                 }
 
-                var addToRoleResult = await _userManager.AddToRoleAsync(appUser, RoleConstants.User);
-                if (!addToRoleResult.Succeeded)
-                {
-                    var errors = string.Join(", ", addToRoleResult.Errors.Select(e => e.Description));
-                    _logger.LogWarning("Adding user {Email} to role failed: {Errors}", dto.Email, errors);
+                return new AuthResultDto { Succeeded = true };
+            });
 
-                    await _unitOfWork.RollbackTransactionAsync();
-                    return new AuthResultDto
-                    {
-                        Succeeded = false,
-                        Errors = addToRoleResult.Errors.Select(e => e.Description)
-                    };
-                }
-
-                var domainUser = new User
-                {
-                    Id = appUser.Id,
-                    FirstName = dto.FirstName,
-                    LastName = dto.LastName
-                };
-                _userRepository.Add(domainUser);
-                
-                // Sign-in before commit to ensure the process is atomic.
-                // If sign-in fails, the transaction will be rolled back.
-                await _signInManager.SignInAsync(appUser, isPersistent: false);
-                
-                await _unitOfWork.CommitTransactionAsync();
-                
-                _logger.LogInformation("User {Email} registered successfully", dto.Email);
-            }
-            catch (Exception ex)
+            if (result.Succeeded && createdUser is not null)
             {
-                _logger.LogError(ex, "An error occurred during registration for user {Email}", dto.Email);
-                throw;
+                await _signInManager.SignInAsync(createdUser, isPersistent: false);
             }
 
-            return new AuthResultDto { Succeeded = true };
+            return result;
         }
     }
 }

--- a/src/SmartEventBooking.Infrastructure/Persistence/Repositories/UnitOfWork.cs
+++ b/src/SmartEventBooking.Infrastructure/Persistence/Repositories/UnitOfWork.cs
@@ -18,6 +18,16 @@ public class UnitOfWork : IUnitOfWork, IDisposable
         return await _context.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task<TResult> ExecuteWithStrategyAsync<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken = default)
+    {
+        var strategy = _context.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(
+            state: operation,
+            operation: static (_, op, _) => op(),
+            verifySucceeded: null,
+            cancellationToken: cancellationToken);
+    }
+
     public async Task BeginTransactionAsync(CancellationToken cancellationToken = default)
     {
         if (_currentTransaction != null)


### PR DESCRIPTION
Wrap user registration in the unit of work execution strategy so transactional identity operations can be retried safely and avoid InvalidOperationException during registration.

Add unit of work support for execution strategies, update auth service to use it, and extend tests to verify the new flow.

Closes #29